### PR TITLE
Fix unicode decoding when string contains non-ascii-representable strings

### DIFF
--- a/plugin.video.abc-iview/resources/lib/utils.py
+++ b/plugin.video.abc-iview/resources/lib/utils.py
@@ -59,7 +59,7 @@ def make_url(d):
 	pairs = []
 	for k,v in d.iteritems():
 		k = urllib.quote_plus(k)
-                # Values can possibly be - UTF-8 as an ASCII str, ASCII as an ASCII str, or unicode. Want clean ASCII for URL.
+		# Values can possibly be - UTF-8 as an ASCII str, ASCII as an ASCII str, or unicode. Want clean ASCII for URL.
 		if not isinstance(v, unicode):
 			v = str(v)
 			v = v.decode("utf-8")


### PR DESCRIPTION
Hi,

I noticed a problem with the current version of the plugin where non-ascii-representable content very occasionaly turns up in a URL component and causes an exception.

You can see this as of this week if you try to view the episode list for "The Chaser: Hamster Wheel Series 2", at least on my system:

```
08:58:28 T:139838713927424  NOTICE: [ABC iView v1.2.0] ERROR: fill_programs_list (63) - 'ascii' codec can't encode character u'\u2013' in position 103: ordinal not in range(128)
08:58:28 T:139838713927424   ERROR: Traceback (most recent call last):
08:58:28 T:139838713927424   ERROR:   File "/home/xbmc/.xbmc/addons/plugin.video.abc/iview/resources/lib/programs.py", line 63, in fill_programs_list
08:58:28 T:139838713927424   ERROR:     item_url = p.make_xbmc_url()
08:58:28 T:139838713927424   ERROR:   File "/home/xbmc/.xbmc/addons/plugin.video.abc-iview/resources/lib/classes.py", line 249, in make_xbmc_url
08:58:28 T:139838713927424   ERROR:     return utils.make_url(d)
08:58:28 T:139838713927424   ERROR:   File "/home/xbmc/.xbmc/addons/plugin.video.abc-iview/resources/lib/utils.py", line 62, in make_url
08:58:28 T:139838713927424   ERROR:     v = str(v)
08:58:28 T:139838713927424   ERROR: UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 103: ordinal not in range(128)
```

The fix attached checks if each url component is already unicode and avoids round-tripping it to a str() and back. The routine might be subtly more complex than it needs to be, I'm working on the assumption (as per the comment I put) that sometimes (some platforms?) you get plain string typed arguments with UTF-8 characters hidden inside, which I figure is why it was implemented that way in the first place.

Every time I have to work with Unicode in Python 2.7 I grow more appreciative of the string handling in Python 3. :)

Thanks heaps for xbmc-addon-abc-iview, btw. It's awesome, we use it every day to watch shows. :)
- Angus
