### PR TITLE
Work around News24 addition to all arrays

### DIFF
--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -190,7 +190,10 @@ def parse_series_items(soup):
 	series_json = json.loads(soup)
 
 	if series_json[0]['a'] == '9900019':
-		index = 1
+		if len(series_json) == 1:
+			index = 0
+		else:
+			index = 1
 	else:
 		index = 0
 
@@ -249,7 +252,10 @@ def parse_series_items(soup):
 		new_program.duration      = item.get('j')
 
 		temp_date = item.get('f')
-		timestamp = time.mktime(time.strptime(temp_date, '%Y-%m-%d %H:%M:%S'))
+		try:
+			timestamp = time.mktime(time.strptime(temp_date, '%Y-%m-%d %H:%M:%S'))
+		except:
+			timestamp = time.mktime(time.strptime(temp_date, '%Y-%m-%d'))
 		new_program.date = datetime.date.fromtimestamp(timestamp)
 
 		programs_list.append(new_program)


### PR DESCRIPTION
This appears to be a bug with the iView API.
