### PR TITLE
Add optional support for progressive HTTP download

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
     <string id="10000">ABC iView</string>
-    
-    <!--Categories-->
-    <string id="10070">Override RTMP Settings</string>
-    
-    <!--Settings-->
-    <string id="10075">Host</string>
-    
+
+    <!-- Categories -->
+    <string id="10080">Settings</string>
+
+    <!-- Video Transport -->
+    <string id="10090">Video Transport</string>
+    <string id="10091">RTMP</string>
+    <string id="10092">HTTP</string>
 </strings>

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -23,6 +23,7 @@ import os
 import version
 
 NAME = 'ABC iView'
+ADDON_ID = 'plugin.video.abc_iview'
 VERSION = version.VERSION
 
 api_version = 383
@@ -36,10 +37,12 @@ except AttributeError:
 
 user_agent = '%s plugin for XBMC %s%s' % (NAME, VERSION, os_string)
 
-base_url   = 'http://www.abc.net.au/iview/'
-config_url = 'http://www.abc.net.au/iview/xml/config.xml?r=%d' % api_version
-auth_url   = 'http://tviview.abc.net.au/iview/auth/?v2'
-series_url = 'http://www.abc.net.au/iview/api/series_mrss.htm?id=%s'
+base_url     = 'http://www.abc.net.au/iview/'
+config_url   = 'http://www.abc.net.au/iview/xml/config.xml?r=%d' % api_version
+auth_url     = 'http://tviview.abc.net.au/iview/auth/?v2'
+series_url   = 'http://www.abc.net.au/iview/api/series_mrss.htm?id=%s'
+redirect_url = 'http://iview.abc.net.au/redirect/legacy/?url='
+feed_url     = 'https://tviview.abc.net.au/iview/feed/samsung/'
 
 akamai_fallback_server = 'rtmp://cp53909.edgefcs.net/ondemand'
 akamai_playpath_prefix = 'flash/playback/_definst_/'

--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -261,3 +261,20 @@ def parse_series_items(soup):
         programs_list.append(new_program)
 
     return programs_list
+
+def parse_new_programme(data):
+    return json.loads(data)
+
+def parse_feed(data):
+    xml = BeautifulStoneSoup(data)
+    items = xml.findAll('item')
+    programs_list = []
+    for item in items:
+        programs_list.append({
+            'title': item.find('title').string,
+            'episode_title': item.find('subtitle').string,
+            'description': item.find('description').string,
+            'url': item.find('link').string,
+            'videoasset': item.find('abc:videoasset').string
+        })
+    return programs_list

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -26,11 +26,17 @@ import classes
 import comm
 
 try:
-    import xbmc, xbmcgui, xbmcplugin
+    import xbmc, xbmcgui, xbmcplugin, xbmcaddon
 except ImportError:
     pass # for PC debugging
 
-def rtmp_url(url):
+def http_url(p):
+    # Work out new series ID
+    program_data = comm.get_new_programme(p.id)
+    feed_data = comm.get_program_from_feed(program_data['episodeHouseNumber'], program_data['seriesHouseNumber'])
+    return feed_data['videoasset']
+
+def rtmp_url(p):
     iview_config = comm.get_config()
     auth = comm.get_auth(iview_config)
 
@@ -42,7 +48,7 @@ def rtmp_url(url):
 
     # Playpath shoud look like this:
     #   Akamai: mp4:flash/playback/_definst_/itcrowd_10_03_02
-    playpath = auth['playpath_prefix'] + url
+    playpath = auth['playpath_prefix'] + p.url
     if playpath.split('.')[-1] == 'mp4':
         playpath = 'mp4:' + playpath
 
@@ -54,12 +60,18 @@ def rtmp_url(url):
     return "%s?auth=%s playpath=%s swfurl=%s swfvfy=true" % (auth['rtmp_url'], auth['token'], playpath, config.swf_url)
 
 def play(url):
+    addon = xbmcaddon.Addon(config.ADDON_ID)
 
     try:
         p = classes.Program()
         p.parse_xbmc_url(url)
 
-        media_url = rtmp_url(p.url)
+        if addon and addon.getSetting('video_transport') == 'HTTP':
+            utils.log('Using HTTP Transport')
+            media_url = http_url(p)
+        else:
+            utils.log('Using RTMP Transport')
+            media_url = rtmp_url(p)
     
         listitem=xbmcgui.ListItem(label=p.get_list_title(), iconImage=p.thumbnail, thumbnailImage=p.thumbnail)
         listitem.setInfo('video', p.get_xbmc_list_item())

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <!-- RTMP Host -->
-    <category label="10075">
-        <setting id="rtmp_host" type="text" label="10070" default="rtmp://" />
-    </category>
+  <category label="10080">
+    <!-- Video Transport -->
+    <setting id="video_transport" type="labelenum" label="10090" lvalues="10091|10092" />
+  </category>
 </settings>


### PR DESCRIPTION
There's been a lot of issues caused by bugs in XBMC's support for RTMP, and considering the RTMP servers are no longer unmetered, we may as well use HTTP streams considering it should be a lot more stable and tested in XBMC. This PR adds it in as an option under the addon settings.

The actual streams are fetched using the new iView website to grab the new series ID, and use that to filter the Smart TV RSS feeds and grab the url for the episode we want to watch.

/cc @andybotting
