### PR TITLE
Restore description & thumbnail to series list

### DIFF
--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -118,6 +118,8 @@ def parse_programme_from_feed(data):
         else:
             show = classes.Series()
             show.title = title
+            show.description = item.find('description').text
+            show.thumbnail = item.find('{http://search.yahoo.com/mrss/}thumbnail').attrib['url']
             show_list.append(show)
 
     return show_list

--- a/resources/lib/series.py
+++ b/resources/lib/series.py
@@ -39,11 +39,9 @@ def make_series_list(url):
         for s in series_list:
             url = "%s?%s" % (sys.argv[0], utils.make_url({'series': s.title, 'category': category}))
 
-            # We don't have access to this right now with the new feed
-            #thumbnail = s.get_thumbnail()
-            #listitem = xbmcgui.ListItem(s.get_list_title(), iconImage=thumbnail, thumbnailImage=thumbnail)
-            #listitem.setInfo('video', { 'plot' : s.get_description() })
-            listitem = xbmcgui.ListItem(s.get_list_title())
+            thumbnail = s.get_thumbnail()
+            listitem = xbmcgui.ListItem(s.get_list_title(), iconImage=thumbnail, thumbnailImage=thumbnail)
+            listitem.setInfo('video', { 'plot' : s.get_description() })
 
             # add the item to the media list
             ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=listitem, isFolder=True)


### PR DESCRIPTION
Thanks a bunch for all your hard work getting this working again so quickly.

Here's a couple of tiny changes to get a thumbnail and description back into the series-list view.
