### PR TITLE
add 'inputstreamaddon' compatibility fix for kodi v19

### DIFF
--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -66,7 +66,10 @@ def play(params):
                          'thumb': thumb})
         if use_ia:
             listitem.setProperty('inputstream', 'inputstream.adaptive')
-            listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+            if utils.get_kodi_major_version() < 19:
+                listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+            else:
+                listitem.setProperty('inputstream', 'inputstream.adaptive')
             listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
             listitem.setProperty('inputstream.adaptive.stream_headers', hdrs)
             listitem.setProperty('inputstream.adaptive.license_key',

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -65,7 +65,6 @@ def play(params):
         listitem.setArt({'icon': thumb,
                          'thumb': thumb})
         if use_ia:
-            listitem.setProperty('inputstream', 'inputstream.adaptive')
             if utils.get_kodi_major_version() < 19:
                 listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
             else:


### PR DESCRIPTION
Fix for deprecated call to `listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')` for kodi v19.

Running v2.0.6. I was unable to play content, with the following error logged:

```
ERROR <general>: CInputStreamAddon::Supports - 'inputstreamaddon' has been deprecated, please use `#KODIPROP:inputstream=inputstream.adaptive` instead
```

Reference:
https://forum.kodi.tv/showthread.php?tid=353560

With aussieaddons repo enabled for dependencies.

NB: The link mentions also changing the manifest type, but I found it unnecessary to fix the issue, ie:

`listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')`
...to...
`listitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')`

...was not required for me.
